### PR TITLE
Try to auto-bind to the partner's domid

### DIFF
--- a/argo-linux/argo-module.c
+++ b/argo-linux/argo-module.c
@@ -3776,7 +3776,8 @@ argo_ioctl(struct file *f, unsigned int cmd, unsigned long arg)
                 {
                     struct argo_ring_id id;
                     memset(&id, 0, sizeof(id));
-                    id.partner_id = XEN_ARGO_DOMID_ANY;
+                    id.partner_id = arg ? connect_addr.domain_id :
+                                          XEN_ARGO_DOMID_ANY;
                     id.domain_id = XEN_ARGO_DOMID_ANY;
                     id.aport = 0;
                     rc = argo_bind(p, &id);


### PR DESCRIPTION
This is part of work to reduce the number of wilcard argo rings
https://github.com/OpenXT/xenclient-oe/pull/1238
https://github.com/OpenXT/xsm-policy/pull/35

By specifying a partner id of XEN_ARGO_DOMID_ANY, we are creating a
wildcard ring.  This is sub-optimal since it requires a broader XSM
policy than a domain specific single-source ring.

Since we are connecting, we usually have a connect_addr with a partner
domid.  Specify that domid as the partner_id for the bind operation
which will create a single source ring.

(bind can also take a NULL connect_addr argument to detach a socket.  In
that case, the socket state should not be ARGO_STATE_IDLE.  This may
make sense for re-assigning a previously used argo ring.)

auto-bind is primarily for when a socket is created and then immediately
connect is called - a typical client socket connection.  Therefore it
seems acceptable to make the above behaviour change.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>