### PR TITLE
gitignore: Add missing entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,0 @@
-# Debuild.
-/libv4v_*.dsc
-/libv4v_*.tar.*z
-/libv4v_*_*.build
-/libv4v_*_*.changes
-/libv4v_*_*.deb
-

--- a/argo-linux/.gitignore
+++ b/argo-linux/.gitignore
@@ -6,6 +6,7 @@ modules.order
 Module.symvers
 *.o
 *.o.cmd
+*.o.d
 .tmp_versions
 tags
 cscope.*

--- a/argo-linux/.gitignore
+++ b/argo-linux/.gitignore
@@ -9,3 +9,7 @@ Module.symvers
 .tmp_versions
 tags
 cscope.*
+*.a
+*.a.cmd
+*.mod
+*.mod.cmd

--- a/libargo/.gitignore
+++ b/libargo/.gitignore
@@ -1,22 +1,65 @@
+## Autotools.
+# http://www.gnu.org/software/automake
 Makefile
 Makefile.in
-aclocal.m4
-ar-lib
-autom4te.cache/
-compile
-config.guess
-config.log
-config.status
-config.sub
-configure
-depcomp
-install-sh
+/ar-lib
+/mdate-sh
+/py-compile
+/test-driver
+/ylwrap
+
+# http://www.gnu.org/software/autoconf
+/autom4te.cache
+/autoscan.log
+/autoscan-*.log
+/aclocal.m4
+/compile
+/config.guess
+config.h
+config.h.in
+config.h.in~
+/config.sub
+/configure
+/configure.scan
+/depcomp
+/install-sh
+/missing
+stamp-h1
+/config.log
+/config.status
+m4
+
+# https://www.gnu.org/software/libtool/
+/ltmain.sh
+.libs
+.deps
 libtool
-ltmain.sh
-m4/
-missing
-src/Makefile
-src/Makefile.in
-src/config.h
-src/config.h.in
-src/stamp-h1
+*-libtool
+
+## C.
+# Prerequisites
+*.d
+
+# Object files
+*.o
+*.ko
+*.obj
+*.elf
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+
+# Shared objects
+*.so
+*.so.*
+*.dylib
+
+# Misc
+libargo.pc
+app/argo-proxy
+app/ttcp-argo
+test/test
+libargo/app/viptables

--- a/vsock-argo/module/.gitignore
+++ b/vsock-argo/module/.gitignore
@@ -8,3 +8,7 @@ Module.symvers
 *.o.d
 *.o.cmd
 .tmp_versions
+*.a
+*.a.cmd
+*.mod
+*.mod.cmd


### PR DESCRIPTION
Gitignores were incomplete, add missing configuration or build artefact that should be ignored.