### PR TITLE
linux-5.x: Amend compilation for Linux 5.3 & GCC 9.2

### DIFF
--- a/argo-linux/argo-module.c
+++ b/argo-linux/argo-module.c
@@ -93,6 +93,12 @@
 #include <linux/pseudo_fs.h>
 #endif
 
+#if ( LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0) )
+# define access_ok_wrapper(type, addr, size) access_ok((addr), (size))
+#else
+# define access_ok_wrapper(type, addr, size) access_ok((type), (addr), (size))
+#endif
+
 #define XEN_ARGO_ROUNDUP(x) roundup((x), XEN_ARGO_MSG_SLOT_SIZE)
 
 #define MOAN do { printk(KERN_ERR "%s:%d MOAN called\n",__FILE__,__LINE__); } while (1==0)
@@ -2662,7 +2668,7 @@ argo_recv_stream(struct argo_private *p, void *_buf, int len, int recv_flags,
             DEBUG_APPLE;
             argo_spin_unlock_irqrestore(&p->pending_recv_lock, flags);
 
-            if ( !access_ok(VERIFY_WRITE, buf, to_copy) )
+            if ( !access_ok_wrapper(VERIFY_WRITE, buf, to_copy) )
             {
                 printk(KERN_ERR "ARGO - ERROR: buf invalid _buf=%p buf=%p len=%d to_copy=%zu count=%zu\n",
                        _buf, buf, len, to_copy, count);
@@ -3355,7 +3361,7 @@ argo_sendto(struct argo_private * p, const void *buf, size_t len, int flags,
 {
     ssize_t rc;
 
-    if ( !access_ok(VERIFY_READ, buf, len) )
+    if ( !access_ok_wrapper(VERIFY_READ, buf, len) )
         return -EFAULT;
 
 #ifdef ARGO_DEBUG
@@ -3447,7 +3453,7 @@ argo_recvfrom(struct argo_private * p, void *buf, size_t len, int flags,
            buf, len, nonblock);
 #endif
  
-    if ( !access_ok (VERIFY_WRITE, buf, len) )
+    if ( !access_ok_wrapper (VERIFY_WRITE, buf, len) )
         return -EFAULT;
 
     if ( flags & MSG_DONTWAIT )
@@ -3751,7 +3757,7 @@ argo_ioctl(struct file *f, unsigned int cmd, unsigned long arg)
             }
             break;
         case ARGOIOCGETSOCKNAME:
-            if ( !access_ok (VERIFY_WRITE, arg, sizeof(struct argo_ring_id)) )
+            if ( !access_ok_wrapper (VERIFY_WRITE, arg, sizeof(struct argo_ring_id)) )
                 return -EFAULT;
             {
                 struct argo_ring_id ring_id;
@@ -3764,7 +3770,7 @@ argo_ioctl(struct file *f, unsigned int cmd, unsigned long arg)
             break;
         case ARGOIOCGETSOCKTYPE:
             DEBUG_APPLE;
-            if ( !access_ok (VERIFY_WRITE, arg, sizeof(int)) )
+            if ( !access_ok_wrapper (VERIFY_WRITE, arg, sizeof(int)) )
                 return -EFAULT;
             {
                 int sock_type;
@@ -3776,7 +3782,7 @@ argo_ioctl(struct file *f, unsigned int cmd, unsigned long arg)
             break;
         case ARGOIOCGETPEERNAME:
             DEBUG_APPLE;
-            if ( !access_ok (VERIFY_WRITE, arg, sizeof(xen_argo_addr_t)) )
+            if ( !access_ok_wrapper (VERIFY_WRITE, arg, sizeof(xen_argo_addr_t)) )
                 return -EFAULT;
             {
                 xen_argo_addr_t addr;
@@ -3821,7 +3827,7 @@ argo_ioctl(struct file *f, unsigned int cmd, unsigned long arg)
         case ARGOIOCGETCONNECTERR:
         {
             unsigned long flags;
-            if ( !access_ok(VERIFY_WRITE, arg, sizeof(int)) )
+            if ( !access_ok_wrapper(VERIFY_WRITE, arg, sizeof(int)) )
                 return -EFAULT;
             DEBUG_APPLE;
 
@@ -3843,7 +3849,7 @@ argo_ioctl(struct file *f, unsigned int cmd, unsigned long arg)
             break;
         case ARGOIOCACCEPT:
             DEBUG_APPLE;
-            if ( !access_ok(VERIFY_WRITE, arg, sizeof(xen_argo_addr_t)) )
+            if ( !access_ok_wrapper(VERIFY_WRITE, arg, sizeof(xen_argo_addr_t)) )
                 return -EFAULT;
             {
                 xen_argo_addr_t addr;
@@ -3940,7 +3946,7 @@ argo_ioctl(struct file *f, unsigned int cmd, unsigned long arg)
         {
             struct xen_argo_viptables_list rules_list;
 
-            if ( !access_ok(VERIFY_WRITE, (void __user *)arg,
+            if ( !access_ok_wrapper(VERIFY_WRITE, (void __user *)arg,
                             sizeof (struct xen_argo_viptables_list)) )
                 return -EFAULT;
 

--- a/argo-linux/argo-module.c
+++ b/argo-linux/argo-module.c
@@ -1632,6 +1632,7 @@ connector_state_machine(struct argo_private *p, struct argo_stream_header *sh)
                 p->pending_error = -ECONNREFUSED;
                 argo_spin_unlock(&p->pending_recv_lock);
             }
+                /* fall through */
             case ARGO_STATE_CONNECTED:
             {
                 p->state = ARGO_STATE_DISCONNECTED;

--- a/argo-linux/argo-module.c
+++ b/argo-linux/argo-module.c
@@ -3114,7 +3114,9 @@ allocate_fd_with_private (void *private)
     int fd;
     const char * name = "";
     struct file *f;
+#if ( LINUX_VERSION_CODE < KERNEL_VERSION(4,19,0) )
     struct path path;
+#endif
     struct inode *ind;
 
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3,7,0))

--- a/argo-linux/include/argo.h
+++ b/argo-linux/include/argo.h
@@ -56,15 +56,20 @@
 })
 #endif
 
+#if ( LINUX_VERSION_CODE < KERNEL_VERSION(5,2,0) )
+#define __xen_stac() stac()
+#define __xen_clac() clac()
+#endif
+
 static inline int __must_check
 HYPERVISOR_argo_op(int cmd, void *arg1, void *arg2, uint32_t arg3,
                    uint32_t arg4)
 {
     int ret;
 
-    stac();
+    __xen_stac();
     ret = _hypercall5(int, argo_op, cmd, arg1, arg2, arg3, arg4);
-    clac();
+    __xen_clac();
 
     return ret;
 }

--- a/argo-linux/include/xen/argo.h
+++ b/argo-linux/include/xen/argo.h
@@ -60,9 +60,9 @@ typedef uint64_t xen_argo_gfn_t;
 typedef struct xen_argo_iov
 {
 #ifdef XEN_GUEST_HANDLE
-    XEN_GUEST_HANDLE(uint8) iov_hnd;
+    XEN_GUEST_HANDLE(const_uint8) iov_hnd;
 #else
-    uint8_t *iov_hnd;
+    const uint8_t *iov_hnd;
 #ifdef CONFIG_ARM /* FIXME: 32-bit ARM only */
     uint32_t pad2;
 #endif

--- a/vsock-argo/module/asm-x86/argo-compat.h
+++ b/vsock-argo/module/asm-x86/argo-compat.h
@@ -23,15 +23,20 @@
 })
 #endif	/* _hypercall5*/
 
+#if ( LINUX_VERSION_CODE < KERNEL_VERSION(5,2,0) )
+#define __xen_stac() stac()
+#define __xen_clac() clac()
+#endif
+
 static inline int __must_check
 HYPERVISOR_argo_op(int cmd, void *arg1, void *arg2, uint32_t arg3,
 	uint32_t arg4)
 {
 	int ret;
 
-	stac();
+	__xen_stac();
 	ret = _hypercall5(int, argo_op, cmd, arg1, arg2, arg3, arg4);
-	clac();
+	__xen_clac();
 
 	return ret;
 }


### PR DESCRIPTION
- Suppress SMAP warnings using `__xen_clac`/`__xen_stac` when available;
- Switch to `init_pseudo` (new interface) for VFS;
- Attend implicit fall through warning in argo chardev;
- Wrap `access_ok()` to handle the new stub in Linux 5.0;
- Add missing Linux version macro for `path` variable in argo chardev;
- Constify the iov pointer passed to argo sendv hypercall.