### PR TITLE
[sshargo] Fix sshargo for target domains with kernel versions < 4.19.0

### DIFF
--- a/argo-linux/argo-module.c
+++ b/argo-linux/argo-module.c
@@ -3112,7 +3112,11 @@ static int
 allocate_fd_with_private (void *private)
 {
     int fd;
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,19,0))
+    const struct qstr name = { .name = "" };
+#else
     const char * name = "";
+#endif
     struct file *f;
 #if ( LINUX_VERSION_CODE < KERNEL_VERSION(4,19,0) )
     struct path path;


### PR DESCRIPTION
An incorrect string type was being passed to d_alloc_pseudo, causing an
ENOMEM error when attempting to sshargo TO domains with older kernel
versions

Signed-off-by: Tyler McGavran <mcgavrant@ainfosec.com>