### PR TITLE
[debug] Remove ridiculous fruit-based debug statements

### DIFF
--- a/argo-linux/argo-module.c
+++ b/argo-linux/argo-module.c
@@ -103,7 +103,6 @@
 
 #define DEFAULT_RING_SIZE     (XEN_ARGO_ROUNDUP((((PAGE_SIZE)*32) - sizeof(xen_argo_ring_t)-XEN_ARGO_ROUNDUP(1))))
 
-#define DEBUG_ORANGE(a) do { printk(KERN_ERR  "%s %s %s:%d cpu%d pid %d\n",a,__PRETTY_FUNCTION__,"argo.c",__LINE__,raw_smp_processor_id(),current->pid); } while (1==0)
 #define ARGO_LOG(tag, va_msg, ...) do { printk(KERN_ERR "argo: [%s] "va_msg, tag, ##__VA_ARGS__); } while (1==0)
 #define ARGO_INFO(va_msg, ...) ARGO_LOG("INFO", va_msg, ##__VA_ARGS__)
 #define ARGO_ERROR(va_msg, ...) ARGO_LOG("ERROR", va_msg, ##__VA_ARGS__)
@@ -117,7 +116,7 @@
 #define ARGO_TRACE ARGO_LOG("TRACE", "%s %s:%d cpu%d pid %d",__PRETTY_FUNCTION__,"argo.c",__LINE__,raw_smp_processor_id(),current->pid)
 #define ARGO_DEBUG(va_msg, ...) ARGO_LOG("DEBUG", va_msg, ##__VA_ARGS__)
 
-#define DEBUG_APPLE DEBUG_ORANGE("")
+#define DEBUG_APPLE ARGO_TRACE
 #define lock2(a,b) do { printk(KERN_ERR  "%s(%s) %s %s:%d cpu%d\n",#a,#b, __PRETTY_FUNCTION__,"argo.c",__LINE__,raw_smp_processor_id()); a(b); } while (1==0)
 #define lock3(a,b,c) do { printk(KERN_ERR  "%s(%s,%s) %s %s:%d cpu%d\n",#a,#b,#c, __PRETTY_FUNCTION__,"argo.c",__LINE__,raw_smp_processor_id()); a(b,c); } while (1==0)
 #define DEBUG_RING(a) summary_ring(a)
@@ -1358,8 +1357,7 @@ copy_into_pending_recv(struct ring *r, int len, struct argo_private *p)
 
     DEBUG_RING(r);
     DEBUG_APPLE;
-    DEBUG_ORANGE ("inserting into pending");
-    ARGO_DEBUG ("IP p=%p k=%d s=%d c=%d\n",
+    ARGO_DEBUG ("inserting into pending: IP p=%p k=%d s=%d c=%d\n",
                 pending, k, p->state, atomic_read (&p->pending_recv_count));
     /*argo_hexdump (&pending->sh, len);*/
     DEBUG_APPLE;
@@ -1880,7 +1878,6 @@ argo_interrupt_rx(void)
 {
     struct ring *r;
 
-    //DEBUG_ORANGE("a");
     DEBUG_APPLE;
 
     argo_read_lock(&list_lock);
@@ -1936,7 +1933,7 @@ argo_interrupt(int irq, void *dev_id)
     unsigned long flags;
 
 #ifdef ARGO_DEBUG_ENABLED
-    DEBUG_ORANGE ("argo_interrupt");
+    DEBUG_APPLE;
 #endif
 
     argo_spin_lock_irqsave(&interrupt_lock, flags);

--- a/argo-linux/argo-module.c
+++ b/argo-linux/argo-module.c
@@ -871,7 +871,6 @@ allocate_ring(struct ring *r, int ring_len)
              (ring_len != XEN_ARGO_ROUNDUP(ring_len)) )
         {
             ARGO_DEBUG ("ring_len=%d\n", ring_len);
-            ARGO_TRACE;
             ret = -EINVAL;
             break;
         }
@@ -959,7 +958,6 @@ new_ring(struct argo_private *sponsor, struct argo_ring_id *pid)
         return -ENOMEM;
     ARGO_TRACE;
     memset (r, 0, sizeof(struct ring));
-    ARGO_TRACE;
 
     ARGO_DEBUG("new_ring: %d\n", sponsor->desired_ring_size);
 
@@ -967,7 +965,6 @@ new_ring(struct argo_private *sponsor, struct argo_ring_id *pid)
 
     ARGO_DEBUG("new_ring: allocate_ring ret: %d\n", ret);
 
-    ARGO_TRACE;
     if ( ret )
     {
         ARGO_TRACE;
@@ -996,7 +993,6 @@ new_ring(struct argo_private *sponsor, struct argo_ring_id *pid)
 
         ARGO_DEBUG ("port = %u\n", id.aport);
 
-        ARGO_TRACE;
         if ( !id.aport )
         {
             ARGO_TRACE;
@@ -1283,7 +1279,6 @@ xmit_queue_inline(struct argo_ring_id *from, xen_argo_addr_t *to,
     {
         argo_spin_unlock_irqrestore (&pending_xmit_lock, flags);
         ARGO_ERROR("Out of memory trying to queue an xmit of %zu bytes\n", len);
-        ARGO_TRACE;
         return -ENOMEM;
     }
 
@@ -1354,11 +1349,9 @@ copy_into_pending_recv(struct ring *r, int len, struct argo_private *p)
     ARGO_TRACE;
 
     DEBUG_RING(r);
-    ARGO_TRACE;
     ARGO_DEBUG ("inserting into pending: IP p=%p k=%d s=%d c=%d\n",
                 pending, k, p->state, atomic_read (&p->pending_recv_count));
     /*argo_hexdump (&pending->sh, len);*/
-    ARGO_TRACE;
 
     argo_spin_lock(&p->pending_recv_lock);
     list_add_tail(&pending->node, &p->pending_recv_list);
@@ -1460,7 +1453,6 @@ argo_notify(void)
 
     if ( H_argo_notify(d) )
     {
-        ARGO_TRACE;
         ARGO_TRACE;
         argo_kfree(d);
         argo_spin_unlock_irqrestore(&pending_xmit_lock, flags);
@@ -2110,7 +2102,6 @@ argo_try_sendv_sponsor(struct argo_private *p,
 
     ARGO_TRACE;
     ret = H_argo_sendv(&addr, dest, iovs, niov, protocol);
-    ARGO_TRACE;
     ARGO_DEBUG ("sendv returned %d\n", ret);
 
     argo_spin_lock_irqsave(&pending_xmit_lock, flags);
@@ -2469,7 +2460,6 @@ argo_recvfrom_dgram(struct argo_private *p, void *buf, size_t len,
     if (!src)
         src = &lsrc;
 
-    ARGO_TRACE;
     ARGO_DEBUG("argo_recvfrom_dgram %p %u %d %d \n", buf, len,
                nonblock, peek);
 
@@ -2773,7 +2763,6 @@ argo_send_stream(struct argo_private *p, const void *_buf, int len,
         }
     }
     ARGO_TRACE;
-    ARGO_TRACE;
 
     while ( len )
     {
@@ -2839,8 +2828,6 @@ argo_send_stream(struct argo_private *p, const void *_buf, int len,
         ARGO_TRACE;
     }
 
-    ARGO_TRACE;
-    ARGO_TRACE;
     ARGO_DEBUG ("count=%d\n", count);
     return count;
 }
@@ -2854,13 +2841,11 @@ argo_bind(struct argo_private *p, struct argo_ring_id *ring_id)
     ARGO_TRACE;
     if ( ring_id->domain_id != XEN_ARGO_DOMID_ANY )
     {
-        ARGO_TRACE;
         ARGO_DEBUG ("ring_id->domain(%x) != XEN_ARGO_DOMID_ANY(%x)",
                ring_id->domain_id, XEN_ARGO_DOMID_ANY);
         return -EINVAL;
     }
 
-    ARGO_TRACE;
     ARGO_DEBUG("argo_bind: %d (d: %d) (s: %d)\n", p->ptype,
            ARGO_PTYPE_DGRAM, ARGO_PTYPE_STREAM);
 
@@ -3922,9 +3907,7 @@ argo_ioctl(struct file *f, unsigned int cmd, unsigned long arg)
         break;
         default:
             ARGO_ERROR("unknown ioctl: cmd=%x ARGOIOCACCEPT=%lx\n", cmd, ARGOIOCACCEPT);
-            ARGO_TRACE;
     }
-    ARGO_TRACE;
     ARGO_DEBUG ("argo_ioctl cmd=%x pid=%d result=%d\n", cmd, current->pid, rc);
     return rc;
 }

--- a/libargo/src/argo.c
+++ b/libargo/src/argo.c
@@ -19,8 +19,6 @@
 
 #include "project.h"
 
-#define I_AM_A_BROKEN_WEENIE
-
 static size_t
 count_iov (struct iovec *iov, int n)
 {
@@ -179,15 +177,9 @@ argo_send (int fd, const void *buf, size_t len, int flags)
   op.flags = flags;
   op.addr = NULL;
 
-#ifdef I_AM_A_BROKEN_WEENIE
   mlock (op.buf, op.len);
-#endif
-
   ret = argo_ioctl (fd, ARGOIOCSEND, &op);
-
-#ifdef I_AM_A_BROKEN_WEENIE
   munlock (op.buf, op.len);
-#endif
 
   return ret;
 }
@@ -212,20 +204,16 @@ argo_sendmsg (int fd, const struct msghdr * msg, int flags)
 
   linearize_iov (op.buf, msg->msg_iov, msg->msg_iovlen);
 
-#ifdef I_AM_A_BROKEN_WEENIE
   mlock (op.buf, op.len);
   if (op.addr)
     mlock (op.addr, sizeof (xen_argo_addr_t));
-#endif
 
   //send is all in kernel
   ret = argo_ioctl (fd, ARGOIOCSEND, &op);
 
-#ifdef I_AM_A_BROKEN_WEENIE
   if (op.addr)
     munlock (op.addr, sizeof (xen_argo_addr_t));
   munlock (op.buf, op.len);
-#endif
 
   free (op.buf);
 
@@ -244,19 +232,15 @@ argo_sendto (int fd, const void *buf, size_t len, int flags,
   op.addr = dest_addr;
   op.flags = flags;
 
-#ifdef I_AM_A_BROKEN_WEENIE
   mlock (op.buf, op.len);
   if (op.addr)
     mlock (op.addr, sizeof (xen_argo_addr_t));
-#endif
 
   ret = argo_ioctl (fd, ARGOIOCSEND, &op);
 
-#ifdef I_AM_A_BROKEN_WEENIE
   if (op.addr)
     munlock (op.addr, sizeof (xen_argo_addr_t));
   munlock (op.buf, op.len);
-#endif
 
   return ret;
 }


### PR DESCRIPTION
and replace with a real logging API.

- Add catch-all ARGO_LOG for logging varying log levels
- Add ARGO_TRACE/DEBUG/INFO/ERROR wrappers around ARGO_LOG
- Replace DEBUG_APPLE, DEBUG_BANANA, DEBUG_ORANGE, and MOAN with the above functions
- Remove excessive logging in certain areas (e.g. a TRACE log followed by an INFO log)
- Remove I_AM_A_BROKEN_WEENIE define

Signed-off-by: Nicholas Tsirakis <tsirakisn@ainfosec.com>