### PR TITLE
gitignore: create/update them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+oe-logs
+oe-workdir

--- a/libargo/.gitignore
+++ b/libargo/.gitignore
@@ -62,4 +62,4 @@ libargo.pc
 app/argo-proxy
 app/ttcp-argo
 test/test
-libargo/app/viptables
+app/viptables


### PR DESCRIPTION
externalsrc depends on a revision created with git add -A. Up to date gitignore would prevent unecessary rebuilds.