### PR TITLE
argo: locking fixes

### DIFF
--- a/argo-linux/argo-module.c
+++ b/argo-linux/argo-module.c
@@ -860,7 +860,7 @@ xmit_queue_wakeup_private(struct argo_ring_id *from,
     if ( delete )
         return;
 
-    p = kmalloc( sizeof(struct pending_xmit), GFP_ATOMIC );
+    p = kmalloc( sizeof(struct pending_xmit), GFP_KERNEL );
     if ( !p )
     {
         pr_err("Out of memory trying to queue an xmit private wakeup\n");
@@ -909,7 +909,7 @@ xmit_queue_wakeup_sponsor(struct argo_ring_id *from, xen_argo_addr_t * to, int l
         return;
 
 
-    p = kmalloc(sizeof(struct pending_xmit), GFP_ATOMIC);
+    p = kmalloc(sizeof(struct pending_xmit), GFP_KERNEL);
     if ( !p )
     {
         pr_err("Out of memory trying to queue an xmit sponsor wakeup\n");
@@ -953,7 +953,7 @@ xmit_queue_inline(struct argo_ring_id *from, xen_argo_addr_t *to,
         return ret;
     }
 
-    p = kmalloc(sizeof(struct pending_xmit) + len, GFP_ATOMIC);
+    p = kmalloc(sizeof(struct pending_xmit) + len, GFP_KERNEL);
     if ( !p )
     {
         mutex_unlock(&pending_xmit_lock);
@@ -1010,8 +1010,8 @@ copy_into_pending_recv(struct ring *r, int len, struct argo_private *p)
     }
 
     pending = kmalloc(sizeof(struct pending_recv) -
-                             sizeof(struct argo_stream_header) + len,
-                           GFP_ATOMIC);
+                          sizeof(struct argo_stream_header) + len,
+                      GFP_KERNEL);
     if ( !pending )
         return -1;
 
@@ -1104,7 +1104,7 @@ argo_notify(void)
     nent = atomic_read(&pending_xmit_count);
 
     d = kmalloc(sizeof(xen_argo_ring_data_t) +
-                     nent * sizeof(xen_argo_ring_data_ent_t), GFP_ATOMIC);
+                nent * sizeof(xen_argo_ring_data_ent_t), GFP_KERNEL);
     if ( !d )
     {
         mutex_unlock(&pending_xmit_lock);

--- a/argo-linux/argo-module.c
+++ b/argo-linux/argo-module.c
@@ -3896,18 +3896,24 @@ argo_init(void)
     argo_platform_device = platform_device_alloc("argo", -1);
     if ( !argo_platform_device )
     {
-        platform_driver_unregister(&argo_driver);
-        return -ENOMEM;
+        error = -ENOMEM;
+        goto error_driver_unregister;
     }
 
     error = platform_device_add(argo_platform_device);
     if ( error )
     {
-        platform_device_put(argo_platform_device);
-        platform_driver_unregister(&argo_driver);
-        return error;
+        goto error_platform_put;
     }
+
     return 0;
+
+ error_platform_put:
+    platform_device_put(argo_platform_device);
+ error_driver_unregister:
+    platform_driver_unregister(&argo_driver);
+
+    return error;
 }
 
 static void __exit


### PR DESCRIPTION
This series addresses locking issues with argo.  argo trips lockdep since the interrupt handler takes the same locks as the ioctl calls.  Also, non-sleeping locks are used throughout when sleep-able functions are called.

Instead of the interrupt handler processing the rings, the handler now scedules a work queue to do the work.  This moves all work into process context, so all locks are converted to sleepable locks.  With a dedicated, high-priority work queue, performance on a basically idle openxt system is comparable to the old code.

I have not seen any lockdep errors running this series.

After https://github.com/OpenXT/linux-xen-argo/commit/adf9f52964608f78807e9c54bd8a7d622ac748b2, I still observed an order 4 allocation failure with GFP_KERNEL.  I'm not sure if there is anything to do there.