### PR TITLE
argo: Return EISCONN when already bound

### DIFF
--- a/argo-linux/argo-module.c
+++ b/argo-linux/argo-module.c
@@ -2430,6 +2430,14 @@ argo_bind(struct argo_private *p, struct argo_ring_id *ring_id)
         return -EINVAL;
     }
 
+    if ( p->r )
+    {
+        pr_debug("ring already connected %d -> %d:%d", p->r->id.domain_id,
+                 p->r->id.aport, p->r->id.partner_id);
+
+        return -EISCONN;
+    }
+
     pr_debug("argo_bind: %d (d: %d) (s: %d)\n", p->ptype,
            ARGO_PTYPE_DGRAM, ARGO_PTYPE_STREAM);
 


### PR DESCRIPTION
Calling bind multiple times would leak rings.  Return -EISCONN for that
case.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>

I've run with this for about a month without issue.

The other option would be to automatically clean up the old ring and continue with the bind.  But doing things silently is not necessarily the best.  I haven't seen anything fail with EISCONN, and applications that break from EISCONN should just be fixed.